### PR TITLE
Add backend multi-server test

### DIFF
--- a/app/routes/backend.py
+++ b/app/routes/backend.py
@@ -1,0 +1,32 @@
+from typing import List
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from app.services.backend import create_backend, modify_backend, delete_backend
+
+router = APIRouter()
+
+class BackendRequest(BaseModel):
+    name: str
+    servers: List[str]
+
+@router.post('/create-backend')
+def create_backend_route(request: BackendRequest):
+    success = create_backend(request.name, request.servers)
+    if not success:
+        raise HTTPException(status_code=400, detail='Backend ya existe')
+    return {'message': 'Backend creado correctamente'}
+
+@router.put('/modify-backend')
+def modify_backend_route(request: BackendRequest):
+    success = modify_backend(request.name, request.servers)
+    if not success:
+        raise HTTPException(status_code=404, detail='Backend no encontrado')
+    return {'message': 'Backend modificado correctamente'}
+
+@router.delete('/delete-backend')
+def delete_backend_route(name: str):
+    success = delete_backend(name)
+    if not success:
+        raise HTTPException(status_code=404, detail='Backend no encontrado')
+    return {'message': 'Backend eliminado correctamente'}

--- a/app/services/backend.py
+++ b/app/services/backend.py
@@ -1,0 +1,89 @@
+import os
+from typing import List
+
+PLACEHOLDER = "########NOTHING HERE##########"
+
+
+def _load_cfg():
+    path = os.environ.get('HAPROXY_CFG_PATH')
+    if not path:
+        raise EnvironmentError("La variable de entorno HAPROXY_CFG_PATH no está definida.")
+    with open(path, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+    return path, lines
+
+
+def create_backend(name: str, servers: List[str]) -> bool:
+    path, lines = _load_cfg()
+
+    header = f"backend {name}"
+    for line in lines:
+        if line.strip().startswith('backend ') and line.strip().split()[1] == name:
+            return False
+
+    new_block = [header + "\n"]
+    for srv in servers:
+        new_block.append(f"    {srv}\n")
+    new_block.append("\n")
+
+    insert_idx = None
+    for i, line in enumerate(lines):
+        if PLACEHOLDER in line:
+            insert_idx = i
+            break
+    if insert_idx is None:
+        lines.extend(new_block)
+    else:
+        lines[insert_idx:insert_idx] = new_block
+
+    with open(path, 'w', encoding='utf-8') as f:
+        f.writelines(lines)
+    return True
+
+
+def _find_backend_block(lines: List[str], name: str):
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip().startswith('backend ') and line.strip().split()[1] == name:
+            start = i
+            break
+    if start is None:
+        return None, None
+
+    end = len(lines)
+    for j in range(start + 1, len(lines)):
+        stripped = lines[j].strip()
+        if stripped.startswith('backend ') or PLACEHOLDER in stripped:
+            end = j
+            break
+    return start, end
+
+
+def modify_backend(name: str, servers: List[str]) -> bool:
+    path, lines = _load_cfg()
+    loc = _find_backend_block(lines, name)
+    if loc == (None, None):
+        return False
+    start, end = loc
+
+    new_block = [f"backend {name}\n"]
+    for srv in servers:
+        new_block.append(f"    {srv}\n")
+    new_block.append("\n")
+
+    lines[start:end] = new_block
+    with open(path, 'w', encoding='utf-8') as f:
+        f.writelines(lines)
+    return True
+
+
+def delete_backend(name: str) -> bool:
+    path, lines = _load_cfg()
+    loc = _find_backend_block(lines, name)
+    if loc == (None, None):
+        return False
+    start, end = loc
+    del lines[start:end]
+    with open(path, 'w', encoding='utf-8') as f:
+        f.writelines(lines)
+    return True

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,79 @@
+import os
+import shutil
+import tempfile
+import pytest
+from unittest import mock
+from app.services.backend import create_backend, modify_backend, delete_backend
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def copy_test_haproxy_cfg():
+    temp_path = tempfile.NamedTemporaryFile(delete=False).name
+    shutil.copy("tests/haproxy.cfg", temp_path)
+    yield temp_path
+    os.remove(temp_path)
+
+
+def test_create_backend(copy_test_haproxy_cfg):
+    with mock.patch.dict(os.environ, {"HAPROXY_CFG_PATH": copy_test_haproxy_cfg}):
+        create_backend("backend_new", ["server srv1 1.1.1.1:80 check"])
+
+        with open(copy_test_haproxy_cfg) as f:
+            contents = f.read()
+        logger.info("\n===== Resultado del haproxy.cfg tras crear backend =====")
+        logger.info(contents)
+        logger.info("==============================================\n")
+
+        assert "backend backend_new" in contents
+        assert "server srv1 1.1.1.1:80 check" in contents
+
+
+def test_create_backend_multiple_servers(copy_test_haproxy_cfg):
+    with mock.patch.dict(os.environ, {"HAPROXY_CFG_PATH": copy_test_haproxy_cfg}):
+        servers = [
+            "server srv1 1.1.1.1:443",
+            "server srv2 1.1.1.2:443",
+            "server srv3 1.1.1.3:443",
+        ]
+        create_backend("backend_multi", servers)
+
+        with open(copy_test_haproxy_cfg) as f:
+            contents = f.read()
+        logger.info("\n===== Resultado del haproxy.cfg tras crear backend con multiples servidores =====")
+        logger.info(contents)
+        logger.info("==============================================\n")
+
+        for srv in servers:
+            assert srv in contents
+
+
+def test_modify_backend(copy_test_haproxy_cfg):
+    with mock.patch.dict(os.environ, {"HAPROXY_CFG_PATH": copy_test_haproxy_cfg}):
+        create_backend("to_mod", ["server old 1.1.1.1:80"])
+        modify_backend("to_mod", ["server new 2.2.2.2:80"])
+
+        with open(copy_test_haproxy_cfg) as f:
+            contents = f.read()
+        logger.info("\n===== Resultado del haproxy.cfg tras modificar backend =====")
+        logger.info(contents)
+        logger.info("==============================================\n")
+
+        assert "server new 2.2.2.2:80" in contents
+        assert "server old 1.1.1.1:80" not in contents
+
+
+def test_delete_backend(copy_test_haproxy_cfg):
+    with mock.patch.dict(os.environ, {"HAPROXY_CFG_PATH": copy_test_haproxy_cfg}):
+        create_backend("to_del", ["server s 1.1.1.1:80"])
+        delete_backend("to_del")
+
+        with open(copy_test_haproxy_cfg) as f:
+            contents = f.read()
+        logger.info("\n===== Resultado del haproxy.cfg tras eliminar backend =====")
+        logger.info(contents)
+        logger.info("==============================================\n")
+
+        assert "backend to_del" not in contents


### PR DESCRIPTION
## Summary
- cover backend creation with multiple server entries

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e1cc3dbc83228fcfb9ce298eabe1